### PR TITLE
Add "datatype" methods and update for "random methods" (v5.5.0+)

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -18,6 +18,7 @@ module.exports = {
           "/api/commerce",
           "/api/company",
           "/api/database",
+          "/api/datatype",
           "/api/date",
           "/api/fake",
           "/api/finance",

--- a/docs/api/datatype.md
+++ b/docs/api/datatype.md
@@ -1,0 +1,124 @@
+# datatype <Badge text="5.5.0+" type="tip" vertical="middle"/>
+
+Generate basic data type, starting from `v5.5.0`. Similar functions from `faker.random` will be deprecated.
+
+## number([options])
+
+Generates random `number` data type.
+
+::: tip
+| Param   | Type  |               Default                |
+| ------- | ----- | :----------------------------------: |
+| options | mixed | `{min: 0, max: 99999, precision: 1}` |
+
+**NOTE**: passing a number as the param will set the `max` value to that number and use the `min` and `precision` defaults
+:::
+
+```js
+faker.datatype.number(); // 3451
+faker.datatype.number(86); // 50
+faker.datatype.number({min:10}); // 45991
+faker.datatype.number({min: 10, max: 100}); // 14
+faker.datatype.number({min: 10, max: 100, precision: .25}); // 44.5
+```
+
+## float([options])
+
+Generates random `float` data type.
+
+::: tip
+| Param   | Type  |               Default                |
+| ------- | ----- | :----------------------------------: |
+| options | mixed | `{min: 0, max: 99999, precision: 1}` |
+
+**NOTE 1**: passing a number as the param will set the `max` value to that number and use the `min` and `precision` defaults
+
+**NOTE 2**: javascript has single data type `number` for all kinds of numbers. Statement `typeof(faker.datatype.number(10)) === typeof(faker.datatype.float(10))` equals `true`
+:::
+
+
+```js
+faker.datatype.float(); // 428
+faker.datatype.float(100); // 23
+faker.datatype.float({min:10}); // 1635
+faker.datatype.float({min: 10, max: 100}); // 49
+faker.datatype.float({min: 10, max: 100, precision: .1}); // 81.8
+```
+
+## array([length])
+
+Generates array of random number or string. 
+
+::: tip
+| Param | Type  |      Default      |
+| ----- | ----- | :---------------: |
+| length | number | 10 |
+
+**NOTE**: this method has no fine-grained control to create array of numbers or strings only, or specify criteria for array elements
+:::
+
+```js
+faker.datatype.array(); // [13,'hfa&', 41, 8301, '(6$bH', 2354, 'V73!', 'm*he?', 11911, 'gbdX#']
+faker.datatype.array(3); // [47460, 'b&r3#', 9003]
+```
+
+## uuid
+
+Generates random UUID
+
+```js
+faker.datatype.uuid(); // 54d13fa1-6d84-4717-8fa2-477a62dac76c 
+```
+
+## boolean
+
+Generates random `boolean` data type.
+
+```js
+faker.datatype.boolean(); // true 
+```
+
+## string([length])
+
+Generates random `string` data type. 
+
+::: tip
+| Param | Type  |      Default      |
+| ----- | ----- | :---------------: |
+| length | number | 10 |
+:::
+
+```js
+faker.datatype.string(); // 'Y7=bR1.jpW'
+faker.datatype.string(5); // '_9Kss'
+```
+
+## json
+
+Generates random JSON. It has default length of 7, and no options.
+
+::: tip
+**NOTE**: The generated data type is `string`. To treat it like javascript `object`, use `JSON.parse()` function.
+:::
+
+```js
+faker.datatype.json(); // {"foo":61342,"bar":1587,"bike":88807,"a":69894,"b":"A?+(5w)E/Z","name":"U@Y`>Ygls}","prop":35014} (string)
+JSON.parse(faker.datatype.json()) // (object)
+```
+
+## hexaDecimal([length])
+
+Generates random hex (base-16) number. 
+
+::: tip
+| Param | Type  |      Default      |
+| ----- | ----- | :---------------: |
+| length | number | 1 |
+**NOTE**: The generated data type is `string`. To treat it like javascript `number`, use `parseInt()` function.
+:::
+
+```js
+faker.datatype.hexaDecimal(); // '0xA' (string)
+faker.datatype.hexaDecimal(5); // '0x8D620' (string)
+parseInt(faker.datatype.hexaDecimal(2)) // 0xC1 (number)
+```

--- a/docs/api/random.md
+++ b/docs/api/random.md
@@ -9,7 +9,9 @@ Generates random number
 | ------- | ----- | :----------------------------------: |
 | options | mixed | `{min: 0, max: 99999, precision: 1}` |
 
-**NOTE**: passing a number as the param will set the `max` value to that number and use the `min` and `precision` defaults
+**NOTE 1**: passing a number as the param will set the `max` value to that number and use the `min` and `precision` defaults
+
+**NOTE 2**: Starting from <Badge text="v5.5.0" type="tip" vertical="middle"/> `faker.datatype.number` is more preferred to use
 :::
 
 ```js
@@ -56,6 +58,10 @@ faker.random.objectElement({ name:'bob', color: 'blue', age: 22}, 'key'); // nam
 
 Returns random UUID
 
+:::tip
+**NOTE**: Starting from <Badge text="v5.5.0" type="tip" vertical="middle"/> `faker.datatype.uuid` is more preferred to use
+:::
+
 ```js
 faker.random.uuid(); // 202e301c-1a22-4ed9-8f86-88e5520a76c6 
 ```
@@ -63,6 +69,10 @@ faker.random.uuid(); // 202e301c-1a22-4ed9-8f86-88e5520a76c6
 ## boolean
 
 Returns random boolean
+
+:::tip
+**NOTE**: Starting from <Badge text="v5.5.0" type="tip" vertical="middle"/> `faker.datatype.uuid` is more preferred to use
+:::
 
 ```js
 faker.random.boolean(); // true 

--- a/docs/api/random.md
+++ b/docs/api/random.md
@@ -71,7 +71,7 @@ faker.random.uuid(); // 202e301c-1a22-4ed9-8f86-88e5520a76c6
 Returns random boolean
 
 :::tip
-**NOTE**: Starting from <Badge text="v5.5.0" type="tip" vertical="middle"/> `faker.datatype.uuid` is more preferred to use
+**NOTE**: Starting from <Badge text="v5.5.0" type="tip" vertical="middle"/> `faker.datatype.boolean` is more preferred to use
 :::
 
 ```js


### PR DESCRIPTION
As of version 5.5.0, faker.js has added new method to generate basic data types, called `datatype`.
I added docs for `datatype` methods.
Some methods are already exist in `random` methods. Those methods are noted as deprecating soon. I added notes on affected methods like `faker.random.uuid` or `faker.random.number`.

I hope this helps the community.